### PR TITLE
docker.compose.version overloaded in compose.sls

### DIFF
--- a/docker/compose-ng.sls
+++ b/docker/compose-ng.sls
@@ -1,5 +1,5 @@
 {%- from "docker/map.jinja" import compose with context %}
-{%- for name, container in compose.items() %}
+{%- for name, container in compose.items() if not name == 'version' %}
   {%- set id = container.container_name|d(name) %}
   {%- set required_containers = [] %}
 {{id}} image:


### PR DESCRIPTION
Needed docker-compose version 1.4.2 installed locally on host, but the compose-ng.sls was expecting every item to be a dict. Filter out dict.
